### PR TITLE
DSBD-43: take arguments as query strings.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/morello-api",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/morello-api",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/morello-api",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "An interface for executing binaries on it's self and morello host.",
   "main": "src/index.ts",
   "scripts": {

--- a/src/controllers/scenario/index.ts
+++ b/src/controllers/scenario/index.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Query,
   Path,
   Route,
 } from 'tsoa'
@@ -41,8 +42,8 @@ export class scenario extends Controller implements IScenario {
   }
   
   @Get('{executable}')
-  public async get(@Path() executable: Executables): Promise<ExamplesResult> {
-    this.log.debug(`attempting to execute ${executable} scenario`)
+  public async get(@Path() executable: Executables , @Query() params: string[]): Promise<ExamplesResult> {
+    this.log.debug(`attempting to execute ${executable} scenario with [${params}] arguments`)
     
     return ({
       cheri: await this.execute(`${executable}-cheri`),

--- a/src/controllers/scenario/index.ts
+++ b/src/controllers/scenario/index.ts
@@ -46,8 +46,8 @@ export class scenario extends Controller implements IScenario {
     this.log.debug(`attempting to execute ${executable} scenario with [${params}] arguments`)
     
     return ({
-      cheri: await this.execute(`${executable}-cheri`),
-      aarch64: await this.execute(`${executable}-aarch64`),
+      cheri: await this.execute(`${executable}-cheri ${params}`),
+      aarch64: await this.execute(`${executable}-aarch64 ${params}`),
     })
   }
 }

--- a/types/models/scenario.ts
+++ b/types/models/scenario.ts
@@ -13,7 +13,7 @@ export interface IScenario {
   readonly address: string
   readonly port: number
   log: typeof Logger
-  get: (executable: Executables) => Promise<ExamplesResult>
+  get: (executable: Executables, params: string[]) => Promise<ExamplesResult>
   execute: (cmd: string) => Promise<HostResponse>
 }
 


### PR DESCRIPTION
### What

- Updated the API service to take an array of arguments via `query string`
- Changes for client side are in -> https://github.com/digicatapult/morello-ui/pull/8