### PR TITLE
Feature/dsbd 52

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/morello-api",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/morello-api",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/morello-api",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/morello-api",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/morello-api",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "An interface for executing binaries on it's self and morello host.",
   "main": "src/index.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/morello-api",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "An interface for executing binaries on it's self and morello host.",
   "main": "src/index.ts",
   "scripts": {

--- a/src/controllers/scenario/__tests__/index.test.js
+++ b/src/controllers/scenario/__tests__/index.test.js
@@ -18,10 +18,8 @@ describe('/scenario/{example} endpoint', () => {
 
   beforeEach(async () => {
     stubs.exec = stub(child, 'exec')
-    stubs.exec.onCall(0).yields(null, 'stdout - some output')
+    stubs.exec.onCall(0).yields(null, 'stdout - success')
     stubs.exec.onCall(1)
-    stubs.exec.onCall(2).yields(null, 'stdout - some output')
-    stubs.exec.onCall(3)
     res = await execute()
   })
 
@@ -33,66 +31,25 @@ describe('/scenario/{example} endpoint', () => {
     beforeEach(async () => {
       stubs.exec.restore()
       stubs.exec = stub(child, 'exec')
-      stubs.exec.onCall(0).yields({ message: 'cheri - error' }, 'stdout - some output')
+      stubs.exec.onCall(0).yields({ message: 'error' }, 'stdout - some error output')
       stubs.exec.onCall(1)
-      stubs.exec.onCall(2).yields({ message: 'aarch64 - error' }, 'stdout - some output')
-      stubs.exec.onCall(3)
       res = await execute()
     })
 
     it('returns correct state along with exceptions if both binaries fail', () => {
-      expect(res).to.include.all.keys(['aarch64', 'cheri'])
-      expect(res.aarch64).to.deep.equal({
-        status: 'error',
-        output: 'stdout - some output',
-        exception: { message: 'aarch64 - error' },
-      })
-      expect(res.cheri).to.deep.equal({
-        status: 'error',
-        output: 'stdout - some output',
-        exception: { message: 'cheri - error' },
-      })
-    })
-  })
-
-  describe('and if some binaries fail and some succeed', () => {
-    beforeEach(async () => {
-      stubs.exec.restore()
-      stubs.exec = stub(child, 'exec')
-      stubs.exec.onCall(0).yields({ msg: 'fatal error' }, 'stdout - some output')
-      stubs.exec.onCall(1)
-      stubs.exec.onCall(2).yields(null, 'it was a success')
-      stubs.exec.onCall(3)
-      res = await execute()
-    })
-
-    it('returns formatted output with one with clear indication of failed ones', () => {
-      expect(res).to.include.all.keys(['aarch64', 'cheri'])
       expect(res).to.deep.equal({
-        aarch64: {
-          status: 'success',
-          output: 'it was a success',
-        },
-        cheri: {
-          status: 'error',
-          output: 'stdout - some output',
-          exception: { msg: 'fatal error' },
-        },
+        status: 'error',
+        output: 'stdout - some error output',
+        exception: { message: 'error' },
       })
     })
   })
 
-  it('returns a formatted output of both architectuures', () => {
-    expect(res).to.include.all.keys(['aarch64', 'cheri'])
+  it('returns a formatted output', () => {
+    expect(res).to.include.all.keys(['output', 'status'])
     expect(res).to.deep.equal({
-      aarch64: {
-        status: 'success',
-        output: 'stdout - some output',
-      },
-      cheri: {
-        status: 'success',
-        output: 'stdout - some output',
-      },
+      status: 'success',
+      output: 'stdout - success',
     })
   })
 })

--- a/src/controllers/scenario/index.ts
+++ b/src/controllers/scenario/index.ts
@@ -7,7 +7,7 @@ import {
 } from 'tsoa'
 import config from 'config'
 import { exec } from 'child_process'
-import { ExamplesResult, IScenario, HostResponse, Executables } from '../../../types'
+import { IScenario, HostResponse, Executables } from '../../../types'
 import Logger from '../../utils/Logger'
 
 @Route('scenario')
@@ -42,12 +42,9 @@ export class scenario extends Controller implements IScenario {
   }
   
   @Get('{executable}')
-  public async get(@Path() executable: Executables , @Query() params: string[]): Promise<ExamplesResult> {
+  public async get(@Path() executable: Executables , @Query() params: string[]): Promise<HostResponse> {
     this.log.debug(`attempting to execute ${executable} scenario with [${params}] arguments`)
     
-    return ({
-      cheri: await this.execute(`${executable}-cheri ${params}`),
-      aarch64: await this.execute(`${executable}-aarch64 ${params}`),
-    })
+    return this.execute(`${executable}-cheri ${params}`)
   }
 }

--- a/src/controllers/scenario/index.ts
+++ b/src/controllers/scenario/index.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Query,
   Path,
   Route,
 } from 'tsoa'
@@ -41,8 +42,8 @@ export class scenario extends Controller implements IScenario {
   }
   
   @Get('{executable}')
-  public async get(@Path() executable: Executables): Promise<ExamplesResult> {
-    this.log.debug(`attempting to execute ${executable} scenario`)
+  public async get(@Path() executable: Executables , @Query() params: string[]): Promise<ExamplesResult> {
+    this.log.debug(`attempting to execute ${executable} scenario with [${params}] arguments`)
     
     return ({
       cheri: await this.execute(`${executable}-cheri`),

--- a/src/controllers/scenario/index.ts
+++ b/src/controllers/scenario/index.ts
@@ -45,6 +45,6 @@ export class scenario extends Controller implements IScenario {
   public async get(@Path() executable: Executables , @Query() params: string[]): Promise<HostResponse> {
     this.log.debug(`attempting to execute ${executable} scenario with [${params}] arguments`)
     
-    return this.execute(`${executable}-cheri ${params}`)
+    return this.execute(`${executable} ${params}`)
   }
 }

--- a/src/controllers/scenario/index.ts
+++ b/src/controllers/scenario/index.ts
@@ -46,8 +46,8 @@ export class scenario extends Controller implements IScenario {
     this.log.debug(`attempting to execute ${executable} scenario with [${params}] arguments`)
     
     return ({
-      cheri: await this.execute(`${executable}-cheri`),
-      aarch64: await this.execute(`${executable}-aarch64`),
+      cheri: await this.execute(`${executable}-cheri ${params}`),
+      aarch64: await this.execute(`${executable}-aarch64 ${params}`),
     })
   }
 }

--- a/types/models/scenario.ts
+++ b/types/models/scenario.ts
@@ -13,7 +13,7 @@ export interface IScenario {
   readonly address: string
   readonly port: number
   log: typeof Logger
-  get: (executable: Executables) => Promise<ExamplesResult>
+  get: (executable: Executables, params: string[]) => Promise<ExamplesResult>
   execute: (cmd: string) => Promise<HostResponse>
 }
 

--- a/types/models/scenario.ts
+++ b/types/models/scenario.ts
@@ -13,11 +13,6 @@ export interface IScenario {
   readonly address: string
   readonly port: number
   log: typeof Logger
-  get: (executable: Executables, params: string[]) => Promise<ExamplesResult>
+  get: (executable: Executables, params: string[]) => Promise<HostResponse>
   execute: (cmd: string) => Promise<HostResponse>
-}
-
-export interface ExamplesResult {
-  aarch64: HostResponse,
-  cheri: HostResponse,
 }


### PR DESCRIPTION
### What

Changed to single binaries execution rather than running in series for cheri and aarch64 within one req

Changes:
- unit test update
- simplified controller as it now executes two commands over ssh rather than 4 (scp + ssh)

- NOTE: this should go after -> https://github.com/digicatapult/morello-api/pull/12 to avoid major conflicts