### PR TITLE
Check executables exist both at startup and before execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/morello-api",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/morello-api",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/morello-api",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "An interface for executing binaries on it's self and morello host.",
   "main": "src/index.ts",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,18 +8,26 @@ import { RegisterRoutes } from './routes'
 import * as swaggerJson from './swagger.json'
 
 import { errorHandler } from './utils/errors'
+import  { validateExecutables } from './utils/executables'
 import logger from './utils/Logger'
 
-const app: Express = express()
-const port: Number = config.get('app.port')
+const start = async () => {
+  await validateExecutables()
 
-app.use(urlencoded({ extended: true }))
-app.use(json())
-app.use(cors())
-RegisterRoutes(app)
-app.use(['/openapi', '/docs', '/swagger'], swaggerUI.serve, swaggerUI.setup(swaggerJson))
-app.use(errorHandler)
+  const app: Express = express()
+  const port: Number = config.get('app.port')
 
-app.listen(port, () => {
-  logger.info('Server is running')
-})
+  app.use(urlencoded({ extended: true }))
+  app.use(json())
+  app.use(cors())
+  RegisterRoutes(app)
+  app.use(['/openapi', '/docs', '/swagger'], swaggerUI.serve, swaggerUI.setup(swaggerJson))
+  app.use(errorHandler)
+
+  app.listen(port, () => {
+    logger.info('Server is running')
+  })
+}
+start()
+
+

--- a/src/utils/executables.ts
+++ b/src/utils/executables.ts
@@ -1,0 +1,36 @@
+import fs from 'fs/promises'
+
+import logger from './Logger'
+import { Executables } from '../../types'
+
+const validExecutables: Executables[] = [
+  'out-of-bounds-access-aarch64',
+  'out-of-bounds-access-cheri',
+  'out-of-bounds-read-aarch64',
+  'out-of-bounds-read-cheri',
+  'out-of-bounds-readV2-aarch64',
+  'out-of-bounds-readV2-cheri',
+  'out-of-bounds-write-aarch64',
+  'out-of-bounds-write-cheri',
+  'use-after-free-aarch64',
+  'use-after-free-cheri',
+]
+
+export const validateExecutables = async () => {
+  for (const executableName of validExecutables) {
+    try {
+      await fs.stat(`bin/${executableName}`)
+    } catch (err) {
+      logger.warn(`Executable ${executableName} could not be found`)
+    }
+  }
+}
+
+export const checkExecutable = async (executableName: string): Promise<boolean> => {
+  try {
+    await fs.stat(`bin/${executableName}`)
+    return true
+  } catch (err) {
+    return false
+  }
+}

--- a/types/models/scenario.ts
+++ b/types/models/scenario.ts
@@ -2,26 +2,26 @@ import { ExecException } from 'child_process'
 import Logger from '../../src/utils/Logger'
 
 export type Executables =
-  'out-of-bounds-access-aarch64' |
-  'out-of-bounds-access-cheri' |
-  'out-of-bounds-read-aarch64' |
-  'out-of-bounds-read-cheri' |
-  'out-of-bounds-readV2-aarch64' |
-  'out-of-bounds-readV2-cheri' |
-  'out-of-bounds-write-aarch64' |
-  'out-of-bounds-write-cheri' |
-  'use-after-free-aarch64' |
-  'use-after-free-cheri'
+  | 'out-of-bounds-access-aarch64'
+  | 'out-of-bounds-access-cheri'
+  | 'out-of-bounds-read-aarch64'
+  | 'out-of-bounds-read-cheri'
+  | 'out-of-bounds-readV2-aarch64'
+  | 'out-of-bounds-readV2-cheri'
+  | 'out-of-bounds-write-aarch64'
+  | 'out-of-bounds-write-cheri'
+  | 'use-after-free-aarch64'
+  | 'use-after-free-cheri'
 
 export type HostResponseSuccess = {
-  status: 'success',
-  output: string,
+  status: 'success'
+  output: string
 }
 
 export type HostResponseError = {
-  status: 'error',
-  output: string,
-  exception: ExecException,
+  status: 'error'
+  output: string
+  exception: ExecException
 }
 
 export type HostResponse = HostResponseSuccess | HostResponseError
@@ -31,5 +31,5 @@ export interface IScenario {
   readonly port: number
   log: typeof Logger
   get: (executable: Executables, params: string[]) => Promise<HostResponse>
-  execute: (cmd: string, params: string[]) => Promise<HostResponse>
+  execute: (cmd: Executables, params: string[]) => Promise<HostResponse>
 }


### PR DESCRIPTION
Add checks for executable existance at both startup and on execution. Note the way I enumerate the possible executables is really ugly (duplication of union variants) but theres no better way in typescript unfortunately.

I also restructured the unit tests for the scenario as they were crazy