### PR TITLE
Add configuration for setting location of binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Use a `.env` at root of the repository to set values for the environment variabl
 | MORELLO_HOST     |    N     | `127.0.0.1` | Morello host name                                                                    |
 | MORELLO_PORT     |    N     |   `1022`    | Morello port                                                                         |
 | MORELLO_USERNAME |    N     |   `root`    | Morello username                                                                     |
+| BINARY_DIR       |    N     |    `bin`    | Directory in which to find scenario binaries                                         |
 
 [default.json](./config/default.json) contains default configuration values.
 

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -8,6 +8,7 @@
     "port": "MORELLO_PORT"
   },
   "app": {
-    "port": "PORT"
+    "port": "PORT",
+    "binaryDir": "BINARY_DIR"
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -8,6 +8,7 @@
     "port": 1022
   },
   "app": {
-    "port": 3000
+    "port": 3000,
+    "binaryDir": "bin"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/morello-api",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/morello-api",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/morello-api",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "An interface for executing binaries on it's self and morello host.",
   "main": "src/index.ts",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,8 @@ import logger from './utils/Logger'
 import { CreateHttpServer } from './server'
 
 const start = async () => {
-  await validateExecutables()
+  const binaryDir: string = config.get('app.binaryDir')
+  await validateExecutables(binaryDir)
 
   const app: Express = await CreateHttpServer()
   const port: number = config.get('app.port')

--- a/src/utils/executables.ts
+++ b/src/utils/executables.ts
@@ -16,19 +16,19 @@ const validExecutables: Executables[] = [
   'use-after-free-cheri',
 ]
 
-export const validateExecutables = async () => {
+export const validateExecutables = async (binaryDir: string) => {
   for (const executableName of validExecutables) {
     try {
-      await fs.stat(`bin/${executableName}`)
+      await fs.stat(`${binaryDir}/${executableName}`)
     } catch (err) {
       logger.warn(`Executable ${executableName} could not be found`)
     }
   }
 }
 
-export const checkExecutable = async (executableName: string): Promise<boolean> => {
+export const checkExecutable = async (binaryDir: string, executableName: string): Promise<boolean> => {
   try {
-    await fs.stat(`bin/${executableName}`)
+    await fs.stat(`${binaryDir}/${executableName}`)
     return true
   } catch (err) {
     return false


### PR DESCRIPTION
Adds a configuration entry at `app.binaryDir` which sets the location at which the morello binaries are located. We are doing this so the infrastructure can state an absolute path where the binaries are located so we're not relying on `CWD` configuration. This config entry can also be set by using the environment variable `BINARY_DIR` and has a default value of `bin` to replicate previous behaviour
